### PR TITLE
Document and comment some of the iterator code

### DIFF
--- a/src/bin/build_distribution.rs
+++ b/src/bin/build_distribution.rs
@@ -36,30 +36,30 @@ fn main() -> Result<(), Box<dyn Error>> {
                         continue;
                     }
                     let bucket = output.value as u64 / bucket_size;
-                    if buckets.contains_key(&bucket) {
+                    if let std::collections::btree_map::Entry::Vacant(e) = buckets.entry(bucket) {
+                        e.insert(1f64);
+                    } else {
                         let v = buckets
                             .get_mut(&bucket)
                             .expect("Unable to get key which buckets contain");
-                        *v = *v + 1f64;
-                    } else {
-                        buckets.insert(bucket, 1f64);
+                        *v += 1f64;
                     }
                 }
             }
         }
-        println!("");
+        println!();
         current_file += 1f64;
     }
 
     println!("Cumulating buckets");
     let mut previous = 0f64;
     for value in buckets.values_mut() {
-        *value = *value + previous;
+        *value += previous;
         previous = *value;
     }
     println!("Normalizing buckets");
     for value in buckets.values_mut() {
-        *value = *value / previous;
+        *value /= previous;
     }
     println!("Writing result");
     let dist = Distribution::new(

--- a/src/bin/calculate_probabilities.rs
+++ b/src/bin/calculate_probabilities.rs
@@ -20,7 +20,7 @@ fn main() {
     );
     print!("\tinput_input_zeros\tinput_input_ones\tinput_input_average_other\tinput_input_average");
     print!("\toutput_output_zeros\toutput_output_ones\toutput_output_average_other\toutput_output_average");
-    println!("");
+    println!();
     for run in result {
         let non_derived_partitions = filter_derived_partitions(&run.partition_tuples);
         print!(
@@ -58,7 +58,7 @@ fn main() {
                 zeros, ones, average_other, average
             );
         };
-        println!("")
+        println!()
     }
 }
 
@@ -74,7 +74,7 @@ fn filter_derived_partitions(
 ) -> Vec<(Partition, Partition)> {
     let max_index = partitions
         .iter()
-        .map(|&(ref in_p, _)| in_p.len())
+        .map(|(in_p, _)| in_p.len())
         .max()
         .unwrap();
     let mut sorted_partitions: Vec<Vec<&(Partition, Partition)>> = Vec::with_capacity(max_index);
@@ -125,7 +125,7 @@ fn is_derived(part: &(Partition, Partition), plus_part: &(Partition, Partition))
     if in_partition_retained.len() == 1 && plus_in_partition.len() == 2 {
         return true;
     }
-    return false;
+    false
 }
 
 #[test]
@@ -157,8 +157,7 @@ fn aggregate_probabilities(probabilities: &Vec<f64>) -> (f64, f64, f64, f64) {
     let ones = probabilities.iter().filter(|&&p| p == 1f64).count() as f64;
     let other: Vec<f64> = probabilities
         .iter()
-        .filter(|&&p| p > 0f64 && p < 1f64)
-        .map(|&e| e)
+        .filter(|&&p| p > 0f64 && p < 1f64).copied()
         .collect();
     let average_other = average(&other);
     let average = average(probabilities);
@@ -172,17 +171,17 @@ fn in_out_probability(
 ) -> f64 {
     partition_tuples
         .iter()
-        .filter(|&&(ref in_partition, ref out_partition)| {
+        .filter(|&(in_partition, out_partition)| {
             let in_set = match in_partition
                 .iter()
-                .find(|set| set.iter().find(|&coin| coin == in_coin).is_some())
+                .find(|set| set.iter().any(|coin| coin == in_coin))
             {
                 Some(set) => set,
                 None => panic!("Did not find in coin in partition"),
             };
             let out_set = match out_partition
                 .iter()
-                .find(|set| set.iter().find(|&coin| coin == out_coin).is_some())
+                .find(|set| set.iter().any(|coin| coin == out_coin))
             {
                 Some(set) => set,
                 None => panic!("Did not find out coin in partition"),
@@ -216,12 +215,12 @@ fn in_in_probability(
 ) -> f64 {
     partition_tuples
         .iter()
-        .filter(|&&(ref in_partition, _)| {
+        .filter(|&(in_partition, _)| {
             in_partition
                 .iter()
                 .find(|set| {
-                    set.iter().find(|&coin| coin == first_in_coin).is_some()
-                        && set.iter().find(|&coin| coin == second_in_coin).is_some()
+                    set.iter().any(|coin| coin == first_in_coin)
+                        && set.iter().any(|coin| coin == second_in_coin)
                 })
                 .is_some()
         })
@@ -238,7 +237,7 @@ fn aggregated_in_in_probability(
         .enumerate()
         .flat_map(|(i, first_in_coin)| {
             in_coins.iter().skip(i + 1).map(move |second_in_coin| {
-                in_in_probability(first_in_coin, second_in_coin, &partition_tuples)
+                in_in_probability(first_in_coin, second_in_coin, partition_tuples)
             })
         })
         .collect();
@@ -252,12 +251,12 @@ fn out_out_probability(
 ) -> f64 {
     partition_tuples
         .iter()
-        .filter(|&&(_, ref out_partition)| {
+        .filter(|&(_, out_partition)| {
             out_partition
                 .iter()
                 .find(|set| {
-                    set.iter().find(|&coin| coin == first_out_coin).is_some()
-                        && set.iter().find(|&coin| coin == second_out_coin).is_some()
+                    set.iter().any(|coin| coin == first_out_coin)
+                        && set.iter().any(|coin| coin == second_out_coin)
                 })
                 .is_some()
         })
@@ -274,7 +273,7 @@ fn aggregated_out_out_probability(
         .enumerate()
         .flat_map(|(i, first_out_coin)| {
             out_coins.iter().skip(i + 1).map(move |second_out_coin| {
-                out_out_probability(first_out_coin, second_out_coin, &partition_tuples)
+                out_out_probability(first_out_coin, second_out_coin, partition_tuples)
             })
         })
         .collect();

--- a/src/bin/cja.rs
+++ b/src/bin/cja.rs
@@ -46,7 +46,7 @@ fn main() {
 fn analyze(options: &ArgMatches) {
     let inputs: Vec<u64> = value_t!(options.value_of("inputs"), String)
         .unwrap_or_else(|e| e.exit())
-        .split(",")
+        .split(',')
         .map(|i| {
             i.parse::<u64>().unwrap_or_else(|e| {
                 println!("Invalid input value {}: {}", i, e);
@@ -56,7 +56,7 @@ fn analyze(options: &ArgMatches) {
         .collect();
     let outputs: Vec<u64> = value_t!(options.value_of("outputs"), String)
         .unwrap_or_else(|e| e.exit())
-        .split(",")
+        .split(',')
         .map(|o| {
             o.parse::<u64>().unwrap_or_else(|e| {
                 println!("Invalid output value {}: {}", o, e);
@@ -83,7 +83,7 @@ fn analyze(options: &ArgMatches) {
             }
         }
     }
-    for &(ref input_sets, ref output_sets) in partition_tuples.iter() {
+    for (input_sets, output_sets) in partition_tuples.iter() {
         println!(
             "Input sets: {:?} Output sets: {:?}",
             input_sets, output_sets
@@ -98,9 +98,9 @@ fn auto(options: &ArgMatches) {
         Some(string) => string,
         None => return print!("No distribution file given!"),
     };
-    let distribution = match read_distribution(&distribution_file_name) {
+    let distribution = match read_distribution(distribution_file_name) {
         Ok(dist) => dist,
-        Err(err) => return print!("Error while reading distribution: {}\n", err),
+        Err(err) => return println!("Error while reading distribution: {}", err),
     };
     let transactions = value_t!(options.value_of("transactions"), u64).unwrap_or_else(|e| e.exit());
     let transaction_size = value_t!(options.value_of("size"), u64).unwrap_or_else(|e| e.exit());
@@ -228,12 +228,12 @@ fn run(
     }
     let duration = now.elapsed();
     Run {
-        num_transactions: num_transactions,
+        num_transactions,
         num_inputs_per_transaction: transaction_size,
         original_transactions: transactions,
-        in_coins: in_coins,
-        out_coins: out_coins,
-        partition_tuples: partition_tuples,
+        in_coins,
+        out_coins,
+        partition_tuples,
         duration_secs: duration.as_secs(),
         duration_nano: duration.subsec_nanos(),
     }

--- a/src/bin/count_outputs.rs
+++ b/src/bin/count_outputs.rs
@@ -16,7 +16,7 @@ fn main() {
         for block in iter {
             for transaction in block.transactions.iter() {
                 for output in transaction.outputs.iter() {
-                    if output.pk_script.len() > 0 {
+                    if !output.pk_script.is_empty() {
                         num_outputs += 1
                     }
                 }

--- a/src/blockchain/mod.rs
+++ b/src/blockchain/mod.rs
@@ -56,12 +56,12 @@ named!(pub parse_block_header<&[u8], BlockHeader>,
                nonce: le_u32 >>
 
                (BlockHeader{
-                   version: version,
+                   version,
                    previous_block_header_hash: reverse_hash(&previous_block_header_hash),
                    merkle_root_hash: reverse_hash(&merkle_root_hash),
-                   time: time,
-                   n_bits: n_bits,
-                   nonce: nonce
+                   time,
+                   n_bits,
+                   nonce
                })
        )
 );
@@ -78,7 +78,7 @@ named!(pub parse_outpoint<&[u8], Outpoint>,
                index: le_u32 >>
                (Outpoint{
                    hash: reverse_hash(&hash),
-                   index: index
+                   index
                })
        )
 );
@@ -91,7 +91,7 @@ pub struct TransactionInput {
 }
 
 fn parse_compact(input: &[u8]) -> IResult<&[u8], u64> {
-    if input.len() < 1 {
+    if input.is_empty() {
         return IResult::Incomplete(Needed::Size(1));
     }
     let rest = &input[1..];
@@ -110,9 +110,9 @@ named!(pub parse_transaction_input<&[u8], TransactionInput>,
                script: take!(script_size) >>
                sequence: le_u32 >>
                (TransactionInput{
-                   previous_output: previous_output,
+                   previous_output,
                    script: script.to_vec(),
-                   sequence: sequence
+                   sequence
                })
        )
 );
@@ -129,7 +129,7 @@ named!(pub parse_transaction_output<&[u8], TransactionOutput>,
                script_size: parse_compact >>
                pk_script: take!(script_size) >>
                (TransactionOutput{
-                   value: value,
+                   value,
                    pk_script: pk_script.to_vec()
                })
        )
@@ -152,10 +152,10 @@ named!(pub parse_transaction<&[u8], Transaction>,
                outputs: count!(parse_transaction_output, tx_out_count as usize) >>
                lock_time: le_u32 >>
                (Transaction{
-                   version: version,
-                   lock_time: lock_time,
-                   inputs: inputs,
-                   outputs: outputs
+                   version,
+                   lock_time,
+                   inputs,
+                   outputs
                })
        )
 );
@@ -173,8 +173,8 @@ named!(pub parse_block<&[u8], Block>,
                transactions: count!(parse_transaction, tx_count as usize) >>
 
                (Block{
-                   header: header,
-                   transactions: transactions
+                   header,
+                   transactions
                })
        )
 );
@@ -186,7 +186,7 @@ pub struct BlockFileIterator {
 impl BlockFileIterator {
     pub fn open<P: AsRef<Path>>(path: P) -> Result<BlockFileIterator, Error> {
         match File::open(path) {
-            Ok(file) => Ok(BlockFileIterator { file: file }),
+            Ok(file) => Ok(BlockFileIterator { file }),
             Err(err) => Err(err),
         }
     }

--- a/src/distribution.rs
+++ b/src/distribution.rs
@@ -29,7 +29,7 @@ fn realize_subsum(v: &Vec<u64>, sum: u64) -> Vec<u64> {
 impl Distribution {
     pub fn new(cumulative_normalized: Vec<(u64, f64)>) -> Distribution {
         Distribution {
-            cumulative_normalized: cumulative_normalized,
+            cumulative_normalized,
         }
     }
 
@@ -149,7 +149,7 @@ impl Distribution {
             let Open01(rand) = random::<Open01<f64>>();
             let coin = match self
                 .cumulative_normalized
-                .binary_search_by(|&(_, ref probability)| {
+                .binary_search_by(|(_, probability)| {
                     probability
                         .partial_cmp(&rand)
                         .expect("Impossible situation")

--- a/src/filters/mod.rs
+++ b/src/filters/mod.rs
@@ -11,6 +11,9 @@ use types::{Filter, Partition, Set};
 #[cfg(test)]
 mod test;
 
+/// Solve decision version of subset sum by brute force, returning true if `sum`
+/// can be exactly expressed by summing a subset of `set`. Complexity is
+/// $O(2^n)$ in the size of the set.
 pub fn is_subset_sum(set: &[u64], sum: &u64) -> bool {
     if sum == &0u64 {
         return true;
@@ -43,6 +46,7 @@ pub fn is_subset_sum(set: &[u64], sum: &u64) -> bool {
     is_subset_sum(tail, remaining_sum) || (tail_sum > sum && is_subset_sum(tail, sum))
 }
 
+/// Enumerates the sumset of a given set.
 pub struct SubsetSumIterator<'a> {
     set: &'a Set,
     set_size: u64,
@@ -86,16 +90,22 @@ impl<'a> Iterator for SubsetSumIterator<'a> {
     }
 }
 
+/// Match sums in the sumset of a given set.
 pub struct SubsetSumsFilter<'a> {
     set: &'a Set,
     bloom_filter: BloomFilter,
 }
 
 impl<'a> SubsetSumsFilter<'a> {
+    /// Initialize the filter. $O(2^n)$ complexity, since the full sumset is
+    /// computed in order to construct a bloom filter.
     pub fn new(set: &'a Set) -> SubsetSumsFilter {
         let mut filter = if set.len() as u32 > u32::MAX {
             BloomFilter::with_rate(0.01, u32::MAX)
         } else {
+            // note that the false positive rate may be significantly higher,
+            // since for small values of set.len() the sumset may be
+            // exponentially larger in some cases
             BloomFilter::with_rate(0.01, set.len() as u32)
         };
         for element in SubsetSumIterator::new(set) {
@@ -109,6 +119,8 @@ impl<'a> SubsetSumsFilter<'a> {
 }
 
 impl<'a> Filter<u64> for SubsetSumsFilter<'a> {
+    /// $O(2^n)$ complexity due to re-evaluation of the sumset by call to
+    /// `is_subset_sum`, except when the bloom filter excludes a query ($O(1)$).
     fn contains(&self, sum: &u64) -> bool {
         match self.bloom_filter.contains(&sum) {
             false => false,
@@ -117,6 +129,7 @@ impl<'a> Filter<u64> for SubsetSumsFilter<'a> {
     }
 }
 
+/// Match sums in the parts of a given set of partitions of a set.
 pub struct PartitionsSubsetSumsFilter<'a> {
     partitions: &'a Vec<Partition>,
     bloom_filter: BloomFilter,
@@ -128,6 +141,9 @@ impl<'a> PartitionsSubsetSumsFilter<'a> {
             Some(partition) => partition.iter().flat_map(|set| set.iter()).count() as u32,
             None => 0,
         };
+        // here too the false positive rate is potentially higher, as coins is
+        // the size of the underlying set, whereas the insertions are elements
+        // of the sumset.
         let mut filter = BloomFilter::with_rate(0.01, coins / 2);
         for partition in partitions {
             for set in partition {
@@ -142,6 +158,8 @@ impl<'a> PartitionsSubsetSumsFilter<'a> {
 }
 
 impl<'a> Filter<u64> for PartitionsSubsetSumsFilter<'a> {
+    /// Complexity is $O(nm)$ where $m$ is the size of the given set of
+    /// partitions, and $n$ is the size of the underlying set.
     fn contains(&self, sum: &u64) -> bool {
         if !self.bloom_filter.contains(&sum) {
             return false;

--- a/src/filters/mod.rs
+++ b/src/filters/mod.rs
@@ -15,7 +15,7 @@ pub fn is_subset_sum(set: &[u64], sum: &u64) -> bool {
     if sum == &0u64 {
         return true;
     }
-    if set.len() < 1 {
+    if set.is_empty() {
         return false;
     }
     if set.len() == 1 {
@@ -54,7 +54,7 @@ impl<'a> SubsetSumIterator<'a> {
     fn new(set: &'a Set) -> SubsetSumIterator {
         let set_size = set.len();
         SubsetSumIterator {
-            set: set,
+            set,
             set_size: set_size as u64,
             power_set_size: BigUint::one() << set_size,
             pattern: Zero::zero(),
@@ -102,7 +102,7 @@ impl<'a> SubsetSumsFilter<'a> {
             filter.insert(&element)
         }
         SubsetSumsFilter {
-            set: set,
+            set,
             bloom_filter: filter,
         }
     }
@@ -135,7 +135,7 @@ impl<'a> PartitionsSubsetSumsFilter<'a> {
             }
         }
         PartitionsSubsetSumsFilter {
-            partitions: partitions,
+            partitions,
             bloom_filter: filter,
         }
     }
@@ -153,6 +153,6 @@ impl<'a> Filter<u64> for PartitionsSubsetSumsFilter<'a> {
                 };
             }
         }
-        return false;
+        false
     }
 }

--- a/src/filters/test.rs
+++ b/src/filters/test.rs
@@ -6,31 +6,31 @@ fn test_is_subset_sum() {
     let mut set = vec![1, 2, 3, 4, 5, 6, 7];
     for subsetsum in SubsetSumIterator::new(&set) {
         assert!(
-            is_subset_sum(&set.as_slice(), &subsetsum),
-            format!(
+            is_subset_sum(set.as_slice(), &subsetsum),
+            
                 "{} is a subset sum of {:?} but is_subset_sum returned false",
                 subsetsum, set
-            )
+            
         )
     }
     set = vec![43, 234, 2, 3453, 32, 23432];
     for subsetsum in SubsetSumIterator::new(&set) {
         assert!(
-            is_subset_sum(&set.as_slice(), &subsetsum),
-            format!(
+            is_subset_sum(set.as_slice(), &subsetsum),
+            
                 "{} is a subset sum of {:?} but is_subset_sum returned false",
                 subsetsum, set
-            )
+            
         )
     }
     set = vec![0, 23, 434, 4343, 234];
     for subsetsum in SubsetSumIterator::new(&set) {
         assert!(
-            is_subset_sum(&set.as_slice(), &subsetsum),
-            format!(
+            is_subset_sum(set.as_slice(), &subsetsum),
+            
                 "{} is a subset sum of {:?} but is_subset_sum returned false",
                 subsetsum, set
-            )
+            
         )
     }
 }

--- a/src/partition/mod.rs
+++ b/src/partition/mod.rs
@@ -114,6 +114,11 @@ impl<'a> Iterator for SumFilteredPartitionIterator<'a> {
     }
 }
 
+/// Enumerates all 2-partitions (all pairs of a non-empty proper subset and its
+/// complement, distinct up to equality of unordered pairs) of a Set.
+///
+/// The maximum size of the set is technically 64, practically limited by
+/// running time which is $O(2^n)$.
 pub struct TupleIterator {
     first: u64,
     set: Set,
@@ -123,6 +128,10 @@ pub struct TupleIterator {
 
 impl TupleIterator {
     fn new(set: Set) -> TupleIterator {
+        // The powerset is indexed by a u64 used as a bit vector, so sizes
+        // larger than 64 are not supported.
+        assert!(set.len() <= 64);
+
         let first = match set.first() {
             Some(v) => v.to_owned(),
             None => 0_u64,

--- a/src/partition/mod.rs
+++ b/src/partition/mod.rs
@@ -24,16 +24,16 @@ impl<'a> SumFilteredPartitionIterator<'a> {
         match tuple_iterator.next() {
             None => SumFilteredPartitionIterator {
                 set: set.clone(),
-                filter: filter,
-                tuple_iterator: tuple_iterator,
+                filter,
+                tuple_iterator,
                 left_set_sum: set.iter().sum(),
                 left_set: Some(set),
                 right_partitions_iterator: None,
             },
             Some((left, right)) => SumFilteredPartitionIterator {
-                set: set,
-                filter: filter.clone(),
-                tuple_iterator: tuple_iterator,
+                set,
+                filter,
+                tuple_iterator,
                 left_set_sum: left.iter().sum(),
                 left_set: Some(left),
                 right_partitions_iterator: Some(Box::new(SumFilteredPartitionIterator::new(
@@ -66,7 +66,7 @@ impl<'a> SumFilteredPartitionIterator<'a> {
                     self.left_set = Some(left.clone());
                     self.left_set_sum = left.iter().sum();
                     self.right_partitions_iterator = Some(Box::new(
-                        SumFilteredPartitionIterator::new(right.clone(), self.filter.clone()),
+                        SumFilteredPartitionIterator::new(right.clone(), self.filter),
                     ));
                     return IterResult::Skip;
                 }
@@ -91,7 +91,7 @@ impl<'a> SumFilteredPartitionIterator<'a> {
                     self.left_set = Some(left.clone());
                     self.left_set_sum = left.iter().sum();
                     self.right_partitions_iterator = Some(Box::new(
-                        SumFilteredPartitionIterator::new(right.clone(), self.filter.clone()),
+                        SumFilteredPartitionIterator::new(right.clone(), self.filter),
                     ));
                     IterResult::Skip
                 }
@@ -123,9 +123,9 @@ pub struct TupleIterator {
 
 impl TupleIterator {
     fn new(set: Set) -> TupleIterator {
-        let first = match set.get(0) {
+        let first = match set.first() {
             Some(v) => v.to_owned(),
-            None => 0 as u64,
+            None => 0_u64,
         };
         let max_pattern = match set.len() {
             0 => 0,
@@ -133,10 +133,10 @@ impl TupleIterator {
             v => 2u64.pow(v as u32 - 1) - 1,
         };
         TupleIterator {
-            first: first,
-            set: set,
+            first,
+            set,
             current_pattern: 1,
-            max_pattern: max_pattern,
+            max_pattern,
         }
     }
 }
@@ -158,6 +158,6 @@ impl Iterator for TupleIterator {
             }
         }
         self.current_pattern += 1;
-        return Some((left_set, right_set));
+        Some((left_set, right_set))
     }
 }

--- a/src/partition/test.rs
+++ b/src/partition/test.rs
@@ -50,9 +50,9 @@ fn regression_test_sum_filtered_partition_iterator() {
             assert!(
                 partition_tuples
                     .iter()
-                    .any(|&(ref in_p, ref out_p)| partition_eq(&in_partition, in_p)
+                    .any(|(in_p, out_p)| partition_eq(&in_partition, in_p)
                         && partition_eq(&out_partition, out_p)),
-                "For expected mapping {:?} {:?} no mapping was generated."
+                "{}", "For expected mapping {:?} {:?} no mapping was generated."
             )
         }
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -8,10 +8,7 @@ pub struct Transaction {
 
 impl Transaction {
     pub fn new(inputs: Set, outputs: Set) -> Transaction {
-        Transaction {
-            inputs: inputs,
-            outputs: outputs,
-        }
+        Transaction { inputs, outputs }
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,5 +1,11 @@
+/// An ordered multi-set of natural numbers represented as a vector. The order
+/// has no meaning apart from indexing the elements so they can be identified.
 pub type Set = Vec<u64>;
+
 pub type Partition = Vec<Set>;
+
+/// An abstract representation of a Bitcoin transaction as two sets of natural
+/// numbers.
 #[derive(Serialize, Deserialize)]
 pub struct Transaction {
     pub inputs: Set,


### PR DESCRIPTION
Caveat: Low effort / noisy PR, but seems justifiable.

Since the code is a bit hard to follow, in trying to evaluate it I ended up adding some comments. Also includes sweeping clippy fixes, on the one hand those improve readability bot on the other it's arguably an unrelated change and touches many more files than the ones I commented, LMK if you'd prefer that to be less hamfisted (e.g. only affect touched files).

There is potentially a bug which can't be triggered, added a FIXME comment for that just for the sake of posterity, though I have no intention on fixing this.

Roughly estimating the complexity led me to conclude that this code could be much improved, potentially making the performance reasonable for slightly larger transactions (not much larger since the overall behavior is still exponential).